### PR TITLE
feat: interactive server selection in list --available

### DIFF
--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,12 +1,143 @@
 import { defineCommand } from "citty";
 import consola from "consola";
-import { loadPackage } from "../core/registry.js";
+import { loadPackage, listPackages } from "../core/registry.js";
 import { detectPlatform, detectRuntimes } from "../core/platform.js";
 import { getServerDir, ensureDataDirs } from "../core/paths.js";
 import { addServer, getServer } from "../core/state.js";
 import { selectInstaller } from "../installers/index.js";
 import { detectClients } from "../clients/index.js";
 import { checkLspHealth } from "../health/lsp-check.js";
+
+export interface InstallOptions {
+  skipConfig?: boolean;
+  skipHealth?: boolean;
+}
+
+/**
+ * Core install pipeline — shared between `install` command and interactive list.
+ * Returns true on success, false on failure.
+ */
+export async function installServer(
+  serverName: string,
+  options: InstallOptions = {},
+): Promise<boolean> {
+  // Check if already installed
+  const existing = await getServer(serverName);
+  if (existing) {
+    consola.warn(`${serverName} is already installed (${existing.version})`);
+    consola.info("Use 'lspforge uninstall' first to reinstall");
+    return false;
+  }
+
+  // Load from registry
+  consola.start(`Looking up ${serverName} in registry...`);
+  const pkg = await loadPackage(serverName);
+  if (!pkg) {
+    consola.error(`Server "${serverName}" not found in registry`);
+    const available = await listPackages();
+    if (available.length > 0) {
+      consola.info(`Available servers: ${available.join(", ")}`);
+    }
+    return false;
+  }
+
+  // Detect platform and runtimes
+  const platformInfo = detectPlatform();
+  const runtimes = await detectRuntimes();
+
+  // Select installer
+  const selected = selectInstaller(pkg.source, runtimes);
+  if (!selected) {
+    consola.error(
+      `No compatible installer found for ${serverName}. Required runtimes not available on PATH.`,
+    );
+    const needed = Object.keys(pkg.source).join(", ");
+    consola.info(`Server supports: ${needed}`);
+    return false;
+  }
+
+  // Install
+  consola.start(`Installing ${serverName} via ${selected.type}...`);
+  await ensureDataDirs();
+  const installDir = getServerDir(serverName);
+
+  let result;
+  try {
+    result = await selected.installer(pkg, installDir, platformInfo);
+  } catch (err) {
+    consola.error(
+      `Installation failed: ${err instanceof Error ? err.message : err}`,
+    );
+    return false;
+  }
+
+  consola.success(
+    `Installed ${serverName} v${result.version} via ${result.source}`,
+  );
+
+  // Health check
+  if (!options.skipHealth) {
+    consola.start("Running health check...");
+    const health = await checkLspHealth(
+      serverName,
+      result.binPath,
+      pkg.lsp.args,
+      pkg.health?.timeout_ms,
+      installDir,
+    );
+
+    if (health.status === "ok") {
+      consola.success(`Health check passed (${health.responseTimeMs}ms)`);
+    } else {
+      consola.warn(`Health check ${health.status}: ${health.error}`);
+    }
+
+    await addServer(serverName, {
+      version: result.version,
+      source: result.source,
+      installPath: installDir,
+      binPath: result.binPath,
+      installedAt: new Date().toISOString(),
+      healthStatus: health.status === "ok" ? "ok" : "error",
+    });
+  } else {
+    await addServer(serverName, {
+      version: result.version,
+      source: result.source,
+      installPath: installDir,
+      binPath: result.binPath,
+      installedAt: new Date().toISOString(),
+      healthStatus: "unknown",
+    });
+  }
+
+  // Configure clients
+  if (!options.skipConfig) {
+    const clients = await detectClients();
+    if (clients.length === 0) {
+      consola.info(
+        "No AI coding tools detected. Use --skip-config or install Claude Code, Copilot CLI, or Codex.",
+      );
+    } else {
+      for (const { name, client } of clients) {
+        try {
+          await client.configure({
+            serverName,
+            binPath: result.binPath,
+            args: pkg.lsp.args,
+            extensionToLanguage: pkg.lsp.extension_to_language,
+          });
+        } catch (err) {
+          consola.warn(
+            `Failed to configure ${name}: ${err instanceof Error ? err.message : err}`,
+          );
+        }
+      }
+    }
+  }
+
+  return true;
+}
 
 export const installCommand = defineCommand({
   meta: {
@@ -31,130 +162,12 @@ export const installCommand = defineCommand({
     },
   },
   async run({ args }) {
-    const serverName = args.server as string;
-
-    // Check if already installed
-    const existing = await getServer(serverName);
-    if (existing) {
-      consola.warn(`${serverName} is already installed (${existing.version})`);
-      consola.info("Use 'lspforge uninstall' first to reinstall");
-      return;
-    }
-
-    // Load from registry
-    consola.start(`Looking up ${serverName} in registry...`);
-    const pkg = await loadPackage(serverName);
-    if (!pkg) {
-      consola.error(`Server "${serverName}" not found in registry`);
-      const { listPackages } = await import("../core/registry.js");
-      const available = await listPackages();
-      if (available.length > 0) {
-        consola.info(`Available servers: ${available.join(", ")}`);
-      }
+    const success = await installServer(args.server as string, {
+      skipConfig: args["skip-config"],
+      skipHealth: args["skip-health"],
+    });
+    if (!success) {
       process.exitCode = 1;
-      return;
-    }
-
-    // Detect platform and runtimes
-    const platformInfo = detectPlatform();
-    const runtimes = await detectRuntimes();
-
-    // Select installer
-    const selected = selectInstaller(pkg.source, runtimes);
-    if (!selected) {
-      consola.error(
-        `No compatible installer found for ${serverName}. Required runtimes not available on PATH.`,
-      );
-      const needed = Object.keys(pkg.source).join(", ");
-      consola.info(`Server supports: ${needed}`);
-      process.exitCode = 1;
-      return;
-    }
-
-    // Install
-    consola.start(
-      `Installing ${serverName} via ${selected.type}...`,
-    );
-    await ensureDataDirs();
-    const installDir = getServerDir(serverName);
-
-    let result;
-    try {
-      result = await selected.installer(pkg, installDir, platformInfo);
-    } catch (err) {
-      consola.error(
-        `Installation failed: ${err instanceof Error ? err.message : err}`,
-      );
-      process.exitCode = 1;
-      return;
-    }
-
-    consola.success(
-      `Installed ${serverName} v${result.version} via ${result.source}`,
-    );
-
-    // Health check
-    if (!args["skip-health"]) {
-      consola.start("Running health check...");
-      const health = await checkLspHealth(
-        serverName,
-        result.binPath,
-        pkg.lsp.args,
-        pkg.health?.timeout_ms,
-        installDir,
-      );
-
-      if (health.status === "ok") {
-        consola.success(`Health check passed (${health.responseTimeMs}ms)`);
-      } else {
-        consola.warn(
-          `Health check ${health.status}: ${health.error}`,
-        );
-      }
-
-      // Save state
-      await addServer(serverName, {
-        version: result.version,
-        source: result.source,
-        installPath: installDir,
-        binPath: result.binPath,
-        installedAt: new Date().toISOString(),
-        healthStatus: health.status === "ok" ? "ok" : "error",
-      });
-    } else {
-      await addServer(serverName, {
-        version: result.version,
-        source: result.source,
-        installPath: installDir,
-        binPath: result.binPath,
-        installedAt: new Date().toISOString(),
-        healthStatus: "unknown",
-      });
-    }
-
-    // Configure clients
-    if (!args["skip-config"]) {
-      const clients = await detectClients();
-      if (clients.length === 0) {
-        consola.info(
-          "No AI coding tools detected. Use --skip-config or install Claude Code, Copilot CLI, or Codex.",
-        );
-      } else {
-        for (const { name, client } of clients) {
-          try {
-            await client.configure({
-              serverName,
-              binPath: result.binPath,
-              args: pkg.lsp.args,
-              extensionToLanguage: pkg.lsp.extension_to_language,
-            });
-          } catch (err) {
-            consola.warn(
-              `Failed to configure ${name}: ${err instanceof Error ? err.message : err}`,
-            );
-          }
-        }
-      }
     }
   },
 });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from "citty";
 import consola from "consola";
 import { loadState } from "../core/state.js";
-import { listPackages } from "../core/registry.js";
+import { listPackages, loadAllPackages } from "../core/registry.js";
 
 export const listCommand = defineCommand({
   meta: {
@@ -18,14 +18,61 @@ export const listCommand = defineCommand({
   },
   async run({ args }) {
     if (args.available) {
-      const packages = await listPackages();
+      const packages = await loadAllPackages();
       if (packages.length === 0) {
         consola.info("No packages found in registry");
         return;
       }
-      consola.info("Available servers:");
-      for (const name of packages) {
-        consola.log(`  ${name}`);
+
+      // Non-interactive mode: plain text list (piped output or non-TTY)
+      if (!process.stdout.isTTY) {
+        for (const pkg of packages) {
+          consola.log(`  ${pkg.name}`);
+        }
+        return;
+      }
+
+      // Interactive mode: show select prompt
+      const state = await loadState();
+      const choices = packages.map((pkg) => {
+        const installed = pkg.name in state.servers;
+        const languages = pkg.languages.join(", ");
+        const label = installed
+          ? `${pkg.name}  (${languages}) [installed]`
+          : `${pkg.name}  (${languages})`;
+        return { label, value: pkg.name, hint: pkg.description };
+      });
+
+      const selected = await consola.prompt("Select a server to install:", {
+        type: "select",
+        options: choices,
+      });
+
+      // User cancelled (Ctrl+C)
+      if (typeof selected === "symbol") {
+        return;
+      }
+
+      // Check if already installed
+      if (selected in state.servers) {
+        consola.info(`${selected} is already installed.`);
+        return;
+      }
+
+      // Confirm and install
+      const confirm = await consola.prompt(
+        `Install ${selected}?`,
+        { type: "confirm" },
+      );
+
+      if (typeof confirm === "symbol" || !confirm) {
+        return;
+      }
+
+      const { installServer } = await import("./install.js");
+      const success = await installServer(selected);
+      if (!success) {
+        process.exitCode = 1;
       }
       return;
     }


### PR DESCRIPTION
## Summary

- `lspforge list -a` now shows an interactive select prompt (via `consola.prompt`) when running in a TTY, letting users browse servers with descriptions and `[installed]` labels, then install directly from the list
- Extracts install pipeline into a reusable `installServer()` function shared by both `install` and `list` commands
- Falls back to plain text output when piped (non-TTY) for scripting compatibility

## Test plan

- [ ] Run `lspforge list -a` in terminal — verify interactive picker appears with server names, languages, and install status
- [ ] Select an uninstalled server — verify install pipeline runs
- [ ] Select an already-installed server — verify it shows "already installed" message
- [ ] Cancel with Ctrl+C — verify clean exit
- [ ] Run `lspforge list -a | cat` — verify plain text fallback
- [ ] Run `lspforge install <server>` — verify it still works as before
- [ ] `npm run typecheck && npm run build && npx vitest run` all pass

Closes #19