### PR TITLE
chore: release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lspforge",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lspforge",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lspforge",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "LSP server manager for AI coding tools",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to 0.5.0

## Changes since v0.4.0

- **feat:** `lspforge update` command to upgrade installed servers (#30)
  - `lspforge update [server]` — update specific or all servers
  - `--check` flag for dry-run
  - `--force` flag to reinstall even if version matches
  - Version comparison for semver and date tags
  - Health check after update, client configs preserved