### PR TITLE
chore: release v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lspforge",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lspforge",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "citty": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lspforge",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "LSP server manager for AI coding tools",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0

### What's new in v0.6.0

- **Checksum verification for binary downloads** (#33) — binary installs now verify SHA-256 checksums when available in the registry, with streaming hash for O(1) memory usage. Checksums populated for rust-analyzer.