### PR TITLE
fix: improve discoverability of 'list --available' flag

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -6,7 +6,7 @@ import { listPackages, loadAllPackages } from "../core/registry.js";
 export const listCommand = defineCommand({
   meta: {
     name: "list",
-    description: "List installed LSP servers",
+    description: "List installed LSP servers (use --available to browse registry)",
   },
   args: {
     available: {
@@ -81,7 +81,7 @@ export const listCommand = defineCommand({
     const servers = Object.entries(state.servers);
 
     if (servers.length === 0) {
-      consola.info("No servers installed. Run 'lspforge install <server>' to get started.");
+      consola.info("No servers installed. Run 'lspforge list --available' to browse servers, or 'lspforge init' to auto-detect.");
       return;
     }
 


### PR DESCRIPTION
## Summary

Improve CLI discoverability by guiding users toward the `--available` flag when they run `lspforge list`.

## Changes

- Updated list command help text to show `(use --available to browse registry)`
- Enhanced empty state message to suggest `lspforge list --available` as the next step

## Why

Users weren't aware that `lspforge list` without flags only shows installed servers. The `--available` flag provides an interactive registry browser with search and selection. This change surfaces that capability upfront.