### PR TITLE
Add Neovim Native LSP Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ lspforge install pyright
 | **Claude Code** | Native (plugin system) | `~/.claude/plugins/lspforge/.lsp.json` | Load plugin: `claude --plugin-dir ~/.claude/plugins/lspforge` |
 | **GitHub Copilot CLI** | Native | `~/.copilot/lsp-config.json` | Restart Copilot CLI to pick up config |
 | **OpenCode / Crush** | Native | `opencode.json` or `.crush.json` in project root | Restart OpenCode/Crush |
+| **Neovim** | Native (0.11+) | `~/.config/nvim/plugin/lspforge/<server>.lua` | Auto-loaded by Neovim |
 
 ### Not supported (no LSP)
 
@@ -183,7 +184,7 @@ Tested across **3 operating systems** on every push via GitHub Actions.
 
 - [x] Core CLI (init, install, uninstall, list, check, doctor)
 - [x] npm, pip, cargo, go, binary installers
-- [x] Claude Code, Copilot CLI, OpenCode/Crush clients
+- [x] Claude Code, Copilot CLI, OpenCode/Crush, Neovim clients
 - [x] 5 bundled server definitions
 - [x] Cross-platform CI (Linux, Windows, macOS)
 - [x] LSP health checks

--- a/issue.md
+++ b/issue.md
@@ -1,0 +1,9 @@
+Add Neovim Native LSP Support
+
+lspforge needs to be able to detect and configure Neovim's built-in LSP (added in Neovim 0.11+).
+
+This issue is to track the implementation of:
+- A new client module (`src/clients/neovim.ts`) that writes configuration to `~/.config/nvim/plugin/lspforge/`.
+- Detection logic to automatically identify and configure `nvim`.
+- Unit tests verifying Neovim configuration workflows.
+- Updating `README.md` to indicate Neovim support.

--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -409,7 +409,7 @@ describe("Neovim config writer", () => {
   it("creates lua config from scratch", async () => {
     await configureNeovim({
       serverName: "pyright",
-      binPath: "/usr/bin/pyright",
+      binPath: join("usr", "bin", "pyright"),
       args: ["--stdio"],
       extensionToLanguage: { ".py": "python" },
     });
@@ -420,7 +420,10 @@ describe("Neovim config writer", () => {
     const content = await readFile(configPath, "utf-8");
     expect(content).toContain("-- _managed_by: lspforge");
     expect(content).toContain("vim.lsp.config['pyright'] = {");
-    expect(content).toContain("cmd = { '/usr/bin/pyright', '--stdio' }");
+
+    // Check paths with escaped backslashes for Windows, or regular for Unix
+    const escapedBinPath = join("usr", "bin", "pyright").replace(/\\/g, "\\\\");
+    expect(content).toContain(`cmd = { '${escapedBinPath}', '--stdio' }`);
     expect(content).toContain("filetypes = { 'python' }");
     expect(content).toContain("vim.lsp.enable('pyright')");
   });

--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -15,6 +15,10 @@ import {
   configureOpenCode,
   unconfigureOpenCode,
 } from "../clients/opencode.js";
+import {
+  configureNeovim,
+  unconfigureNeovim,
+} from "../clients/neovim.js";
 
 // ─── Claude Code ───────────────────────────────────────────────────────────
 // configureClaudeCode reads homedir() at call time, so overriding
@@ -378,5 +382,74 @@ describe("OpenCode config writer", () => {
 
     const config = JSON.parse(await readFile(configPath, "utf-8"));
     expect(config.lsp.pyright).toBeDefined();
+  });
+});
+
+// ─── Neovim ────────────────────────────────────────────────────────────────
+
+describe("Neovim config writer", () => {
+  let tempDir: string;
+  let originalXdgConfigHome: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "lspforge-neovim-test-"));
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = tempDir;
+  });
+
+  afterEach(async () => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    await rm(tempDir, { recursive: true });
+  });
+
+  it("creates lua config from scratch", async () => {
+    await configureNeovim({
+      serverName: "pyright",
+      binPath: "/usr/bin/pyright",
+      args: ["--stdio"],
+      extensionToLanguage: { ".py": "python" },
+    });
+
+    const configPath = join(tempDir, "nvim", "plugin", "lspforge", "pyright.lua");
+    expect(existsSync(configPath)).toBe(true);
+
+    const content = await readFile(configPath, "utf-8");
+    expect(content).toContain("-- _managed_by: lspforge");
+    expect(content).toContain("vim.lsp.config['pyright'] = {");
+    expect(content).toContain("cmd = { '/usr/bin/pyright', '--stdio' }");
+    expect(content).toContain("filetypes = { 'python' }");
+    expect(content).toContain("vim.lsp.enable('pyright')");
+  });
+
+  it("unconfigure removes file if managed by lspforge", async () => {
+    const configPath = join(tempDir, "nvim", "plugin", "lspforge", "pyright.lua");
+    await mkdir(join(tempDir, "nvim", "plugin", "lspforge"), { recursive: true });
+
+    await configureNeovim({
+      serverName: "pyright",
+      binPath: "/usr/bin/pyright",
+      args: ["--stdio"],
+      extensionToLanguage: { ".py": "python" },
+    });
+
+    expect(existsSync(configPath)).toBe(true);
+
+    await unconfigureNeovim("pyright");
+
+    expect(existsSync(configPath)).toBe(false);
+  });
+
+  it("unconfigure does not remove file if not managed by lspforge", async () => {
+    const configPath = join(tempDir, "nvim", "plugin", "lspforge", "pyright.lua");
+    await mkdir(join(tempDir, "nvim", "plugin", "lspforge"), { recursive: true });
+    await writeFile(configPath, "print('custom config')", "utf-8");
+
+    await unconfigureNeovim("pyright");
+
+    expect(existsSync(configPath)).toBe(true);
   });
 });

--- a/src/__tests__/e2e-install.test.ts
+++ b/src/__tests__/e2e-install.test.ts
@@ -193,7 +193,7 @@ describe.skipIf(!E2E_ENABLED)("E2E: pip installer (python-lsp-server)", { timeou
     dataDir = getDataDir(fakeHome);
     cliPath = join(process.cwd(), "dist", "cli.js");
     env = getCliEnv(fakeHome);
-  });
+  }, 30_000);
 
   afterAll(async () => {
     await forceRemove(fakeHome);
@@ -380,7 +380,7 @@ describe.skipIf(!E2E_ENABLED)("E2E: update command (typescript-language-server)"
     // Install the server at the current registry version
     const { code } = runCli(cliPath, env, 90_000, "install", "typescript-language-server");
     expect(code).toBe(0);
-  });
+  }, 180_000);
 
   afterAll(async () => {
     await forceRemove(fakeHome);

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -2,6 +2,7 @@ import { commandExists } from "../utils/spawn.js";
 import { configureClaudeCode } from "./claude-code.js";
 import { configureCopilotCli } from "./copilot-cli.js";
 import { configureOpenCode } from "./opencode.js";
+import { configureNeovim } from "./neovim.js";
 
 export interface ClientConfig {
   serverName: string;
@@ -59,6 +60,15 @@ export async function detectClients(): Promise<DetectedClient[]> {
         unconfigure: unconfigureOpenCode,
       },
     },
+    {
+      name: "Neovim",
+      check: () => commandExists("nvim"),
+      client: {
+        name: "Neovim",
+        configure: configureNeovim,
+        unconfigure: unconfigureNeovim,
+      },
+    },
   ];
 
   for (const { name, check, client } of checks) {
@@ -83,5 +93,10 @@ async function unconfigureCopilotCli(serverName: string): Promise<void> {
 
 async function unconfigureOpenCode(serverName: string): Promise<void> {
   const { unconfigureOpenCode: fn } = await import("./opencode.js");
+  await fn(serverName);
+}
+
+async function unconfigureNeovim(serverName: string): Promise<void> {
+  const { unconfigureNeovim: fn } = await import("./neovim.js");
   await fn(serverName);
 }

--- a/src/clients/neovim.ts
+++ b/src/clients/neovim.ts
@@ -1,0 +1,66 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import type { ClientConfig } from "./index.js";
+import consola from "consola";
+
+function getConfigDir(): string {
+  // Use XDG_CONFIG_HOME if available, otherwise default to ~/.config
+  const configHome = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+  return join(configHome, "nvim", "plugin", "lspforge");
+}
+
+function getConfigPath(serverName: string): string {
+  return join(getConfigDir(), `${serverName}.lua`);
+}
+
+/**
+ * Configure a server in Neovim using native LSP format (Neovim 0.11+).
+ * Writes to ~/.config/nvim/plugin/lspforge/<serverName>.lua
+ */
+export async function configureNeovim(
+  config: ClientConfig,
+): Promise<void> {
+  const configDir = getConfigDir();
+  await mkdir(configDir, { recursive: true });
+
+  const configPath = getConfigPath(config.serverName);
+
+  // Convert extensions (e.g., .ts) to Neovim filetypes (e.g., typescript)
+  const filetypes = Array.from(new Set(Object.values(config.extensionToLanguage)));
+
+  const luaConfig = `-- _managed_by: lspforge
+vim.lsp.config['${config.serverName}'] = {
+  cmd = { '${config.binPath}', ${config.args.map(arg => `'${arg}'`).join(", ")} },
+  filetypes = { ${filetypes.map(ft => `'${ft}'`).join(", ")} },
+}
+vim.lsp.enable('${config.serverName}')
+`;
+
+  await writeFile(configPath, luaConfig, "utf-8");
+
+  consola.success(`Configured ${config.serverName} in Neovim (Native LSP)`);
+}
+
+/**
+ * Remove a managed server from Neovim LSP config.
+ */
+export async function unconfigureNeovim(
+  serverName: string,
+): Promise<void> {
+  const configPath = getConfigPath(serverName);
+
+  try {
+    if (existsSync(configPath)) {
+      const content = await readFile(configPath, "utf-8");
+      if (content.includes("-- _managed_by: lspforge")) {
+        await rm(configPath);
+      }
+    }
+  } catch (err) {
+    consola.warn(
+      `Could not unconfigure ${serverName} from Neovim: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}

--- a/src/clients/neovim.ts
+++ b/src/clients/neovim.ts
@@ -30,9 +30,13 @@ export async function configureNeovim(
   // Convert extensions (e.g., .ts) to Neovim filetypes (e.g., typescript)
   const filetypes = Array.from(new Set(Object.values(config.extensionToLanguage)));
 
+  // Escape backslashes for Windows paths in Lua strings
+  const escapedBinPath = config.binPath.replace(/\\/g, "\\\\");
+  const escapedArgs = config.args.map(arg => arg.replace(/\\/g, "\\\\"));
+
   const luaConfig = `-- _managed_by: lspforge
 vim.lsp.config['${config.serverName}'] = {
-  cmd = { '${config.binPath}', ${config.args.map(arg => `'${arg}'`).join(", ")} },
+  cmd = { '${escapedBinPath}', ${escapedArgs.map(arg => `'${arg}'`).join(", ")} },
   filetypes = { ${filetypes.map(ft => `'${ft}'`).join(", ")} },
 }
 vim.lsp.enable('${config.serverName}')


### PR DESCRIPTION
- Implemented a new Neovim client module to configure LSP servers for Neovim via native 0.11+ APIs (`vim.lsp.config`).
- Configurations are written to `~/.config/nvim/plugin/lspforge/` so that Neovim auto-loads them.
- Updated the registry of AI tools to detect and configure Neovim.
- Created robust unit testing for the new Neovim configuration workflows in `clients.test.ts`.
- Updated `README.md` to formally document Neovim support.

---
*PR created automatically by Jules for task [10067210976723526212](https://jules.google.com/task/10067210976723526212) started by @svivekvarma*